### PR TITLE
Added make_safe_callback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed
 ## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
+catkin_python_setup()
 
 ################################################
 ## Declare ROS messages, services and actions ##

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+# fetch values from package.xml
+setup_args = generate_distutils_setup(
+    packages=['ros_utils'],
+    package_dir={'': 'src'},
+)
+
+setup(**setup_args)

--- a/src/ros_utils/make_safe_callback.py
+++ b/src/ros_utils/make_safe_callback.py
@@ -1,0 +1,12 @@
+import rospy
+
+def make_safe_callback(f):
+    def f_safe(*args, **kwargs):
+        try:
+            result = f(*args, **kwargs)
+        except Exception:
+            import traceback
+            rospy.logerr(traceback.format_exc())
+            rospy.signal_shutdown('Exception in callback')
+        return result
+    return f_safe


### PR DESCRIPTION
`make_safe_callback` takes a callback and returns another callback that will crash the node if an exception is thrown, tested and is very helpful.